### PR TITLE
Dockerfile no longer builds because of vanished requirement

### DIFF
--- a/compose/bots_complete/Dockerfile
+++ b/compose/bots_complete/Dockerfile
@@ -46,8 +46,7 @@ RUN python /bots/postinstall.py
 
 
 # Install DevCron
-# failed, missing hg/mercurial : RUN pip install -e hg+https://bitbucket.org/dbenamy/devcron#egg=devcron
-RUN pip install https://bitbucket.org/dbenamy/devcron/get/tip.tar.gz
+RUN pip install devcron==0.4
 
 # Copy Supervisord.conf file
 COPY ./compose/bots_complete/supervisord.conf /etc/supervisor/supervisord.conf

--- a/compose/bots_complete/README.md
+++ b/compose/bots_complete/README.md
@@ -66,4 +66,4 @@ Read more here: [Supervisord.org](http://supervisord.org)
 
 ## crontab
 The crontab file is copied to the bots/config directory from where the dev-cron is started. When the file is changed, the service may require to be restarted to get the updates (untested..., but definitly if the host is shared from the host). 
-Read more here: [DevCron](https://bitbucket.org/dbenamy/devcron/overview)
+Read more here: [DevCron](https://github.com/dbenamy/devcron)


### PR DESCRIPTION
## Why
We should be able to use Docker to run BOTS.

## What
- [x] Dockerfile is fixed and the BOTS container image can be built

## Notes
The `https://bitbucket.org/dbenamy/devcron` repo that was used as a requirement in the Dockerfile no longer exists so the Docker build does not complete.